### PR TITLE
Add support for Resource Owner Password Credentials

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,11 +43,20 @@ class User
   end
 
   class << self
+
     def find(username)
       begin
         new(username: username).get unless username.nil?
       rescue Net::HTTPServerException
 
+      end
+    end
+
+    def authenticate(username, password)
+      begin
+        self.find(username) if self.new.chef.post_rest('authenticate_user', { username: username, password: password })
+      rescue Net::HTTPServerException
+        
       end
     end
   end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -15,6 +15,10 @@ Doorkeeper.configure do
     user
   end
 
+  resource_owner_from_credentials do |routes|
+    User.authenticate(params[:username], params[:password])
+  end 
+
   # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
   admin_authenticator do
     # Put your admin authentication logic here.

--- a/lib/chef_resource.rb
+++ b/lib/chef_resource.rb
@@ -16,11 +16,11 @@ module ChefResource
     raise NotImplementedError, 'A Chef resource URL (e.g., "users/applejack") is required.'
   end
 
-  private 
+  def chef
+    ::Chef::REST.new endpoint, Settings.chef.superuser, nil, parameters
+  end
 
-    def chef
-      ::Chef::REST.new endpoint, Settings.chef.superuser, nil, parameters
-    end
+  private 
 
     def endpoint
       Settings.chef.endpoint


### PR DESCRIPTION
This adds support for the [resource-owner password credentials](http://oauthlib.readthedocs.org/en/latest/oauth2/grants/password.html) flow.  E.g.:

```
curl -X POST -d "username={yourname}&password={yourpass}&grant_type=password&client_id={your-app-id}&client_secret={your-app-secret}" https://yourserver.com/id/oauth/token
```
