### PR TITLE
update doorkeeper to 1.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     diffy (3.0.6)
-    doorkeeper (1.4.0)
+    doorkeeper (1.4.1)
       railties (>= 3.1)
     erubis (2.7.0)
     execjs (2.0.2)
@@ -145,7 +145,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.0)
-    minitest (5.4.3)
+    minitest (5.5.0)
     mixlib-authentication (1.3.0)
       mixlib-log
     mixlib-cli (1.5.0)


### PR DESCRIPTION
Addresses missing CSRF protection found added in https://github.com/doorkeeper-gem/doorkeeper/commit/c1b5c45e2c42c0191ca9f12a2836e31ee1a8de57.
