### PR TITLE
Add the rspec load call for rake_task

### DIFF
--- a/lib/tasks/travis-ci.rake
+++ b/lib/tasks/travis-ci.rake
@@ -1,4 +1,5 @@
 begin
+  require 'rspec/core/rake_task'
 
   namespace :travis do
     desc "Run all specs in except for the request specs"


### PR DESCRIPTION
This is needed to actually trigger the LoadError. If it isn't present
then the rescue block will never fire and the uninitialized constant
error for RSpec will still happen in prod.