### PR TITLE
Make the health checks a little more robust

### DIFF
--- a/lib/health_check.rb
+++ b/lib/health_check.rb
@@ -22,6 +22,7 @@ class HealthCheck
   #
   def check
     erchef_health
+    erchef_key
     postgres_health
     overall
   end
@@ -40,7 +41,21 @@ class HealthCheck
   #
   def erchef_health
     erchef_health_metric do
-      chef.get_rest '_status'
+      output = chef.get_rest '_status'
+
+      if output['status'] != 'pong'
+        @erchef[:status] = ERRORING
+      end
+    end
+  end
+
+  #
+  # Try to fetch /users/pivotal, which will only succeed if we have the correct
+  # webui_priv.pem key in place.
+  #
+  def erchef_key
+    erchef_health_metric do
+      chef.get_rest '/users/pivotal'
     end
   end
 


### PR DESCRIPTION
- Check for "pong" in the returned status from erchef and change status if it's
not there.
- Try to fetch the pivotal user details, which will fail if the correct
webui_priv.pem key is not in place.

This is a little after-the-fact, but @stevendanna was kind enough to give me some good feedback on some questions I had about my original work on the status endpoint.  I think this should make it a little more robust without creating any extra hassle elsewhere.