### PR TITLE
WIP Ra/vi 75 - Profile Page onto oc-id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ group :development, :test do
 end
 
 group :development do
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'quiet_assets'
   gem 'spring' # App preloading
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.0)
     awesome_print (1.6.1)
+    better_errors (1.1.0)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -389,6 +392,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   capybara (~> 2.4.4)
   chef (~> 11.10.4)
   chef-web-core!

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,7 @@
+class ProfilesController < ApplicationController
+
+  def show
+    
+  end
+
+end

--- a/app/views/profiles/_change_password.html.erb
+++ b/app/views/profiles/_change_password.html.erb
@@ -1,0 +1,34 @@
+<div class="medium-12 columns">
+  <h3>Change Your Password</h3>
+    <form data-abide>
+      <div class="row">
+        <div class="medium-12 columns username-field">
+          <label>Current Password
+            <input type="text" required />
+          </label>
+          <small class="error">Required</small>
+        </div>
+      </div>
+      <div class="row">
+        <div class="medium-12 columns username-field">
+          <label>New Password
+            <input type="text" required />
+          </label>
+          <small class="error">Required</small>
+        </div>
+      </div>
+      <div class="row">
+        <div class="medium-12 columns username-field">
+          <label>Confirm Password
+            <input type="text" required />
+          </label>
+          <small class="error">Required</small>
+        </div>
+      </div>
+      <div class="row">
+        <div class="medium-12 columns">
+          <button type="submit" class="button">Change Password</button>
+        </div>
+      </div>
+    </form>
+</div>

--- a/app/views/profiles/_generate_key.html.erb
+++ b/app/views/profiles/_generate_key.html.erb
@@ -1,0 +1,3 @@
+<div class="medium-4-columns">
+  <button type="sumbit" class="button">Key Button</button>
+</div>

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -1,0 +1,41 @@
+<div class="medium-12 columns">
+  <h3>Profile</h3>
+    <form data-abide>
+      <div class="row">
+        <div class="medium-12 columns username-field">
+          <label>First Name
+            <input type="text" required />
+          </label>
+          <small class="error">Required</small>
+        </div>
+      </div>
+      <div class="row">
+        <div class="medium-12 columns username-field">
+          <label>Middle Name
+            <input type="text" required />
+          </label>
+        </div>
+      </div>
+      <div class="row">
+        <div class="medium-12 columns username-field">
+          <label>Last Name
+            <input type="text" required />
+          </label>
+          <small class="error">Required</small>
+        </div>
+      </div>
+      <div class="row">
+        <div class="medium-12 columns username-field">
+          <label>Email Address
+            <input type="text" required />
+          </label>
+          <small class="error">Required</small>
+        </div>
+      </div>
+      <div class="row">
+        <div class="medium-12 columns">
+          <button type="submit" class="button">Save Changes</button>
+        </div>
+      </div>
+    </form>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,27 @@
+<div class="row">
+  <div class="medium-4 columns">
+    <div>
+      <%= render "profile" %>
+    </div>
+  </div>
+  <div class="medium-4 columns">
+    <div>
+      <%= render "change_password" %>
+    </div>
+  </div>
+  <div class="medium-4 columns">
+    <div>
+      <div class="medium-12 columns">
+        <h3>Reset Your Private Key</h3>
+        <p>If you've lost your private key, or would like to replace it, click the button below to download one now.</p>
+        <p>
+          When you do this,
+          <strong>your old key will stop working.</strong>
+          This key replaces your current key.
+          We do not store a copy of this key, so please keep it somewhere safe.
+        </p>
+        <%= render "generate_key" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ OcId::Application.routes.draw do
     resources :sessions, only: [:new, :create, :destroy]
     resource :password_reset, path: '/password-reset', except: [:destroy, :edit]
 
+    resource :profile
+
     resource :zendesk, only: [:show] do
       get 'signout', to: 'zendesks#signout'
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema.define(version: 20140313153625) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "oauth_access_grants", force: true do |t|
+  create_table "oauth_access_grants", force: :cascade do |t|
     t.string   "resource_owner_id", null: false
     t.integer  "application_id",    null: false
     t.string   "token",             null: false
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 20140313153625) do
 
   add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
 
-  create_table "oauth_access_tokens", force: true do |t|
+  create_table "oauth_access_tokens", force: :cascade do |t|
     t.string   "resource_owner_id"
     t.integer  "application_id"
     t.string   "token",             null: false
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 20140313153625) do
   add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
   add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
 
-  create_table "oauth_applications", force: true do |t|
+  create_table "oauth_applications", force: :cascade do |t|
     t.string   "name",         null: false
     t.string   "uid",          null: false
     t.string   "secret",       null: false


### PR DESCRIPTION
This is not ready to be merged, but I've made some progress and would like to check in. 

When a user navigates to /id/profile, he or she sees the identity management components that used to be in account manage. (I did not remove those components from account manage, rather they have been duplicated here.) I created a profile controller to keep these components separate from the applications section of the app. 

Per @cnunciato 's suggestion, I omitted the Gravatar component and the 'Community Profile' and 'Need Help' boxes that are currently on the profile page in account manage. 

Next steps/questions:
1. Per @smith 's initial guidance, the forms are all currently static (including the profile, change password, and generate key forms). Is hooking up the forms within the scope of this ticket?
2. The show method in the profile controller is currently empty. Should anything else be included here?
3. Anything else I'm missing?

General feedback is very welcome, as usual. :smile: Thank you!

